### PR TITLE
Skip lib check to prevent TS2502 error

### DIFF
--- a/clients/Admin/tsconfig.json
+++ b/clients/Admin/tsconfig.json
@@ -22,6 +22,7 @@
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
+    "skipLibCheck": true,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true


### PR DESCRIPTION
Prevents error TS2502 due to outdated libraries.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
